### PR TITLE
put the personality count in an enum instead

### DIFF
--- a/source/Personality.cpp
+++ b/source/Personality.cpp
@@ -19,91 +19,55 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "DataNode.h"
 #include "DataWriter.h"
 
-#include <map>
-#include <vector>
-
 using namespace std;
 
 namespace {
-	// Make sure the length of PersonalityTrait matches PERSONALITY_COUNT
-	// or the game will crash at runtime.
-	enum PersonalityTrait {
-		PACIFIST,
-		FORBEARING,
-		TIMID,
-		DISABLES,
-		PLUNDERS,
-		HUNTING,
-		STAYING,
-		ENTERING,
-		NEMESIS,
-		SURVEILLANCE,
-		UNINTERESTED,
-		WAITING,
-		DERELICT,
-		FLEEING,
-		ESCORT,
-		FRUGAL,
-		COWARD,
-		VINDICTIVE,
-		SWARMING,
-		UNCONSTRAINED,
-		MINING,
-		HARVESTS,
-		APPEASING,
-		MUTE,
-		OPPORTUNISTIC,
-		MERCIFUL,
-		TARGET,
-		MARKED,
-		LAUNCHING,
-		DARING,
-		SECRETIVE,
-		RAMMING
-	};
-
-	const map<string, PersonalityTrait> TOKEN = {
-		{"pacifist", PACIFIST},
-		{"forbearing", FORBEARING},
-		{"timid", TIMID},
-		{"disables", DISABLES},
-		{"plunders", PLUNDERS},
-		{"hunting", HUNTING},
-		{"staying", STAYING},
-		{"entering", ENTERING},
-		{"nemesis", NEMESIS},
-		{"surveillance", SURVEILLANCE},
-		{"uninterested", UNINTERESTED},
-		{"waiting", WAITING},
-		{"derelict", DERELICT},
-		{"fleeing", FLEEING},
-		{"escort", ESCORT},
-		{"frugal", FRUGAL},
-		{"coward", COWARD},
-		{"vindictive", VINDICTIVE},
-		{"swarming", SWARMING},
-		{"unconstrained", UNCONSTRAINED},
-		{"mining", MINING},
-		{"harvests", HARVESTS},
-		{"appeasing", APPEASING},
-		{"mute", MUTE},
-		{"opportunistic", OPPORTUNISTIC},
-		{"merciful", MERCIFUL},
-		{"target", TARGET},
-		{"marked", MARKED},
-		{"launching", LAUNCHING},
-		{"daring", DARING},
-		{"secretive", SECRETIVE},
-		{"ramming", RAMMING}
-	};
-
-	// Tokens that combine two or more flags.
-	const map<string, vector<PersonalityTrait>> COMPOSITE_TOKEN = {
-		{"heroic", {DARING, HUNTING}}
-	};
-
 	const double DEFAULT_CONFUSION = 10.;
 }
+
+
+
+const map<string, Personality::PersonalityTrait> Personality::TOKEN = {
+	{"pacifist", PACIFIST},
+	{"forbearing", FORBEARING},
+	{"timid", TIMID},
+	{"disables", DISABLES},
+	{"plunders", PLUNDERS},
+	{"hunting", HUNTING},
+	{"staying", STAYING},
+	{"entering", ENTERING},
+	{"nemesis", NEMESIS},
+	{"surveillance", SURVEILLANCE},
+	{"uninterested", UNINTERESTED},
+	{"waiting", WAITING},
+	{"derelict", DERELICT},
+	{"fleeing", FLEEING},
+	{"escort", ESCORT},
+	{"frugal", FRUGAL},
+	{"coward", COWARD},
+	{"vindictive", VINDICTIVE},
+	{"swarming", SWARMING},
+	{"unconstrained", UNCONSTRAINED},
+	{"mining", MINING},
+	{"harvests", HARVESTS},
+	{"appeasing", APPEASING},
+	{"mute", MUTE},
+	{"opportunistic", OPPORTUNISTIC},
+	{"merciful", MERCIFUL},
+	{"target", TARGET},
+	{"marked", MARKED},
+	{"launching", LAUNCHING},
+	{"daring", DARING},
+	{"secretive", SECRETIVE},
+	{"ramming", RAMMING}
+};
+
+
+
+// Tokens that combine two or more flags.
+const map<string, vector<Personality::PersonalityTrait>> Personality::COMPOSITE_TOKEN = {
+	{"heroic", {DARING, HUNTING}}
+};
 
 
 

--- a/source/Personality.h
+++ b/source/Personality.h
@@ -20,6 +20,9 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Point.h"
 
 #include <bitset>
+#include <map>
+#include <string>
+#include <vector>
 
 class DataNode;
 class DataWriter;
@@ -31,6 +34,48 @@ class DataWriter;
 // behaviors, like plundering ships or launching surveillance drones, that are
 // used to make some fleets noticeably different from others.
 class Personality {
+private:
+	enum PersonalityTrait {
+		PACIFIST,
+		FORBEARING,
+		TIMID,
+		DISABLES,
+		PLUNDERS,
+		HUNTING,
+		STAYING,
+		ENTERING,
+		NEMESIS,
+		SURVEILLANCE,
+		UNINTERESTED,
+		WAITING,
+		DERELICT,
+		FLEEING,
+		ESCORT,
+		FRUGAL,
+		COWARD,
+		VINDICTIVE,
+		SWARMING,
+		UNCONSTRAINED,
+		MINING,
+		HARVESTS,
+		APPEASING,
+		MUTE,
+		OPPORTUNISTIC,
+		MERCIFUL,
+		TARGET,
+		MARKED,
+		LAUNCHING,
+		DARING,
+		SECRETIVE,
+		RAMMING,
+
+		// Ensure this is last so it can be used for bounds checking.
+		// Otherwise, the game will abort at runtime due to out-of-bounds
+		// access in std::bitset<PERSONALITY_COUNT>
+		PERSONALITY_COUNT
+	};
+
+
 public:
 	Personality() noexcept;
 
@@ -95,11 +140,10 @@ private:
 
 
 private:
-	// Make sure this matches the number of items in PersonalityTrait,
-	// or the game will abort at runtime.
-	static const int PERSONALITY_COUNT = 32;
-
 	bool isDefined = false;
+
+	static const std::map<std::string, PersonalityTrait> TOKEN;
+	static const std::map<std::string, std::vector<PersonalityTrait>> COMPOSITE_TOKEN;
 
 	std::bitset<PERSONALITY_COUNT> flags;
 	double confusionMultiplier;


### PR DESCRIPTION
An alternative being discussed in https://github.com/endless-sky/endless-sky/pull/8423 and https://github.com/endless-sky/endless-sky/pull/8425

This puts the PERSONALITY_COUNT in an enum so the Personality::flags will have the right length.
