### PR TITLE
this should not go to endless-sky: Fix remnant mission bug (scanning cloaked Starling) by adding a `decloaked` personality

### DIFF
--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -3324,7 +3324,7 @@ mission "Remnant: Keystone Research 5"
 				accept
 	npc "scan outfits" "save"
 		government "Remnant (Research)"
-		personality coward disables plunders staying surveillance target mining
+		personality coward disables plunders staying surveillance target mining decloaked
 		system "Peragenor"
 		ship "Starling (Keystone)" "Winds of Light"
 		dialog
@@ -3344,7 +3344,7 @@ mission "Remnant: Keystone Research 6"
 	source "Viminal"
 	npc "scan outfits" "save"
 		government "Remnant (Research)"
-		personality coward disables plunders staying surveillance target mining
+		personality coward disables plunders staying surveillance target mining decloaked
 		system "Peragenor"
 		ship "Starling" "Winds of Light"
 		dialog

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -415,7 +415,7 @@ void AI::UpdateKeys(PlayerInfo &player, Command &activeCommands)
 	// Only toggle the "cloak" command if one of your ships has a cloaking device.
 	if(activeCommands.Has(Command::CLOAK))
 		for(const auto &it : player.Ships())
-			if(!it->IsParked() && it->Attributes().Get("cloak"))
+			if(!it->IsParked() && it->CanCloak())
 			{
 				isCloaking = !isCloaking;
 				Messages::Add(isCloaking ? "Engaging cloaking device." : "Disengaging cloaking device."
@@ -2854,7 +2854,7 @@ bool AI::DoHarvesting(Ship &ship, Command &command) const
 // Check if this ship should cloak. Returns true if this ship decided to run away while cloaking.
 bool AI::DoCloak(Ship &ship, Command &command)
 {
-	if(ship.Attributes().Get("cloak"))
+	if(ship.CanCloak())
 	{
 		// Never cloak if it will cause you to be stranded.
 		const Outfit &attributes = ship.Attributes();

--- a/source/Personality.cpp
+++ b/source/Personality.cpp
@@ -61,6 +61,7 @@ namespace {
 		DARING,
 		SECRETIVE,
 		RAMMING,
+		DECLOAKED,
 
 		// This must be last so it can be used for bounds checking.
 		LAST_ITEM_IN_PERSONALITY_TRAIT_ENUM
@@ -99,7 +100,8 @@ namespace {
 		{"lingering", LINGERING},
 		{"daring", DARING},
 		{"secretive", SECRETIVE},
-		{"ramming", RAMMING}
+		{"ramming", RAMMING},
+		{"decloaked", DECLOAKED}
 	};
 
 	// Tokens that combine two or more flags.
@@ -403,6 +405,13 @@ bool Personality::IsMarked() const
 bool Personality::IsMute() const
 {
 	return flags.test(MUTE);
+}
+
+
+
+bool Personality::IsDecloaked() const
+{
+	return flags.test(DECLOAKED);
 }
 
 

--- a/source/Personality.h
+++ b/source/Personality.h
@@ -81,6 +81,7 @@ public:
 	bool IsTarget() const;
 	bool IsMarked() const;
 	bool IsMute() const;
+	bool IsDecloaked() const;
 
 	// Current inaccuracy in this ship's targeting:
 	const Point &Confusion() const;
@@ -98,7 +99,7 @@ private:
 private:
 	// Make sure this matches the number of items in PersonalityTrait,
 	// or the build will fail.
-	static const int PERSONALITY_COUNT = 33;
+	static const int PERSONALITY_COUNT = 34;
 
 	bool isDefined = false;
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2964,6 +2964,13 @@ double Ship::Cloaking() const
 
 
 
+bool Ship::CanCloak() const
+{
+	return attributes.Get("cloak") && !personality.IsDecloaked();
+}
+
+
+
 bool Ship::IsEnteringHyperspace() const
 {
 	return hyperspaceSystem;

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -256,6 +256,8 @@ public:
 	// Get the degree to which this ship is cloaked. 1 means invisible and
 	// impossible to hit or target; 0 means fully visible.
 	double Cloaking() const;
+	// Is this ship capable of cloaking?
+	bool CanCloak() const;
 	// Check if this ship is entering (rather than leaving) hyperspace.
 	bool IsEnteringHyperspace() const;
 	// Check if this ship is entering or leaving hyperspace.


### PR DESCRIPTION
**Bugfix:** Fixes (INSERT HERE) wherein you must scan a Starling that often cloaks. Uses a new *decloaked* personality.

## Fix Details
In both `Remnant: Keystone Research 5` and `Remnant: Keystone Research 6`:

```ruby
	npc "scan outfits" "save"
		government "Remnant (Research)"

		# This ship will not cloak, even if it has a cloaking device
		personality ... decloaked

		system "Peragenor"
		ship "Starling (Keystone)" "Winds of Light"
```

## Testing Done

### Test 1: Test the feature directly

1. Put this in data/[cloaktest.txt](https://github.com/UnorderedSigh/endless-sky/files/11708012/cloaktest.txt)
2. Depart
3. Land on a planet with a spaceport. (Avoid busy systems or Remnant.)
4. Visit the spaceport.
5. Depart. 
6. Try cloaking and decloaking. The Starlings will *not* cloak, but the Gulls will.

### Test 2: Try the missions
1. Load this: [Friction Diction~3024-12-14 buggy mission scan.txt](https://github.com/UnorderedSigh/endless-sky/files/11708007/Friction.Diction.3024-12-14.buggy.mission.scan.txt)
2. Fly to the next planet.
3. Play the mission.
4. Also play the next one.

## Save File
This save file can be used to verify the bugfix. The bug will occur when using `226df696e`, and will not occur when using this branch's build.
[Friction Diction~3024-12-14 buggy mission scan.txt](https://github.com/UnorderedSigh/endless-sky/files/11708007/Friction.Diction.3024-12-14.buggy.mission.scan.txt)

